### PR TITLE
Filter out non content links

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ libraryDependencies ++= Seq(
     "com.google.appengine" % "appengine-api-1.0-sdk" % "1.9.17",
     "org.jsoup" % "jsoup" % "1.8.1",
     "javax.servlet" % "servlet-api" % "2.5" % "provided",
+    "org.parboiled" %% "parboiled" % "2.0.1",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 


### PR DESCRIPTION
Requested by Celine.

Celine is only interested in the position of **content** links within a container. 

However, containers may also contain 'treats' which are links to tag pages, other fronts, crosswords etc. Filter these out.

